### PR TITLE
Feat 1 precomputed aggregates

### DIFF
--- a/src/__tests__/datasource.test.ts
+++ b/src/__tests__/datasource.test.ts
@@ -72,7 +72,7 @@ describe('Datasource Query', () => {
       label
     };
     const tsTargetD: TimeSeriesQueryLike = {
-      refId: 'C',
+      refId: 'D',
       id: id4,
       granularity: '1h',
       rawDataEnabled: true

--- a/src/datasources/TimeseriesDatasource.ts
+++ b/src/datasources/TimeseriesDatasource.ts
@@ -195,21 +195,24 @@ export class TimeseriesDatasource {
       })
     );
 
-    data = data.reduce((acc: DataSourceItem[], current: DataSourceItem) => {
+    // merge data after split by the refId
+    data = Object.values(data.reduce((acc: { [key: string]: DataSourceItem }, current: DataSourceItem) => {
       const currentId = current.target.refId;
       const currentDatapoints = current.data.items[0].datapoints;
 
-      const index = acc.findIndex(c => c.target.refId === currentId);
-
-      if (index !== -1) {
-        const datapoints = acc[index].data.items[0].datapoints;
-
-        acc[index].data.items[0].datapoints = datapoints.concat(currentDatapoints)
+      if (acc[currentId]) {
+        // Concatenate the datapoints if the item already exists in the accumulator
+        acc[currentId].data.items[0].datapoints = [
+          ...acc[currentId].data.items[0].datapoints,
+          ...currentDatapoints,
+        ];
       } else {
-        acc.push(current);
+        // Otherwise, add the new item to the accumulator
+        acc[currentId] = current;
       }
+
       return acc;
-    }, [] as DataSourceItem[])
+    }, {}));
 
     const filteredData = data
       .filter(item => item.data && 'items' in item.data) as DataSourceItem[];

--- a/src/datasources/TimeseriesDatasource.ts
+++ b/src/datasources/TimeseriesDatasource.ts
@@ -139,7 +139,7 @@ export class TimeseriesDatasource {
           }));
         }
 
-        // When rawDataEnabled or granularity is less than 1h, just use the single time frame
+        // if rawDataEnabled or granularity is less than 1h, just use the single time frame
         return [getDataQueryRequestItem({
           target,
           timeFrame: [start, end],
@@ -167,19 +167,19 @@ export class TimeseriesDatasource {
     const filteredData = data
       .filter(item => item.data && 'items' in item.data) as DataSourceItem[];
 
-    // Consolidate data items by 'refId' after splitting the range
+    // consolidate data items by 'refId' after splitting the range
     const consolidatedData = Object.values(filteredData.reduce((acc: { [key: string]: DataSourceItem }, current: DataSourceItem) => {
       const currentId = current.target.refId;
       const currentDatapoints = current?.data?.items?.[0].datapoints || [];
 
       if (acc[currentId]) {
-        // Concatenate the datapoints if the item already exists in the accumulator
+        // concatenate the datapoints if the item already exists in the accumulator
         acc[currentId].data.items[0].datapoints = [
           ...acc[currentId].data.items[0].datapoints,
           ...currentDatapoints,
         ];
       } else {
-        // Otherwise, add the new item to the accumulator
+        // otherwise, add the new item to the accumulator
         acc[currentId] = current;
       }
 

--- a/src/datasources/TimeseriesDatasource.ts
+++ b/src/datasources/TimeseriesDatasource.ts
@@ -15,7 +15,7 @@ import {
   DataSourceRequestOptions,
   QueryProxyType,
 } from '../types';
-import {getRange, isGranularityGreaterOrEqual1h, splitRange} from '../utils';
+import {getRange, splitRange} from '../utils';
 import {handleError} from '../appEventHandler';
 
 export function getDataQueryRequestItem(props: {
@@ -131,7 +131,7 @@ export class TimeseriesDatasource {
       .flatMap(target => {
         const { rawDataEnabled, granularity } = target;
 
-        if (!rawDataEnabled && isGranularityGreaterOrEqual1h(granularity)) {
+        if (!rawDataEnabled && granularity && granularity.includes('h')) {
           return splitRange([start, end]).map(range => getDataQueryRequestItem({
             target,
             timeFrame: [range.start, range.end],

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export interface TimeSeriesQuery extends DataQuery {
   id: string;
   granularity?: string;
   label?: string;
-  rawDataEnabled?: boolean;
+  rawDataEnabled: boolean;
   name?: string;
   aggregation: AggregatesType;
 }
@@ -129,7 +129,7 @@ export interface ProxyResponseDataPointItem {
 
 export interface ProxyResponseItem {
   id: string;
-  name: string;
+  name?: string;
 }
 
 export interface ProxyResponseDataItem extends ProxyResponseItem {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export interface TimeSeriesQuery extends DataQuery {
   id: string;
   granularity?: string;
   label?: string;
-  rawDataEnabled: boolean;
+  rawDataEnabled?: boolean;
   name?: string;
   aggregation: AggregatesType;
 }
@@ -129,7 +129,7 @@ export interface ProxyResponseDataPointItem {
 
 export interface ProxyResponseItem {
   id: string;
-  name?: string;
+  name: string;
 }
 
 export interface ProxyResponseDataItem extends ProxyResponseItem {

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,3 +166,9 @@ export interface QueryRequestError {
 }
 
 export type DropdownOptions = Promise<Array<SelectableValue<string>>>;
+
+export type Range = {
+  start: number;
+  end: number;
+  precomputed?: boolean;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,35 +28,6 @@ export function stringifyDataError(error: any) {
   return errorMessage;
 }
 
-export function isGranularityGreaterOrEqual1h(granularity: string | undefined): boolean {
-  if(!granularity) {
-    return false;
-  }
-  // define the number of seconds for each unit
-  const unitToSeconds = {
-    s: 1,
-    m: 60,
-    h: 3600,
-    d: 86400,
-  };
-
-  // extract the time value and the unit from the granularity string
-  const matches = granularity.match(/^(\d+)([smhd])$/);
-
-  if (!matches) {
-    return false;
-  }
-
-  const value = parseInt(matches[1], 10);
-  const unit = matches[2] as keyof typeof unitToSeconds;
-
-  // convert granularity to seconds
-  const granularityInSeconds = value * unitToSeconds[unit];
-
-  // check if granularity is greater than or equal to 1 hour (3600 seconds)
-  return granularityInSeconds >= unitToSeconds['h'];
-}
-
 export function splitRange(timeFrame: [start: number, end: number]): Range[] {
   const start = timeFrame[0];
   const end = timeFrame[1];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,8 +42,9 @@ export function isGranularityGreaterOrEqual1h(granularity: string | undefined): 
 
   // extract the time value and the unit from the granularity string
   const matches = granularity.match(/^(\d+)([smhd])$/);
+
   if (!matches) {
-    throw new Error('Invalid granularity format');
+    return false;
   }
 
   const value = parseInt(matches[1], 10);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,9 @@ export function stringifyDataError(error: any) {
 }
 
 export function isGranularityGreaterOrEqual1h(granularity: string | undefined): boolean {
-  if(!granularity) return false;
+  if(!granularity) {
+    return false;
+  }
   // Define the number of seconds for each unit
   const unitToSeconds = {
     s: 1,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export function isGranularityGreaterOrEqual1h(granularity: string | undefined): 
   if(!granularity) {
     return false;
   }
-  // Define the number of seconds for each unit
+  // define the number of seconds for each unit
   const unitToSeconds = {
     s: 1,
     m: 60,
@@ -40,7 +40,7 @@ export function isGranularityGreaterOrEqual1h(granularity: string | undefined): 
     d: 86400,
   };
 
-  // Extract the time value and the unit from the granularity string
+  // extract the time value and the unit from the granularity string
   const matches = granularity.match(/^(\d+)([smhd])$/);
   if (!matches) {
     throw new Error('Invalid granularity format');
@@ -49,10 +49,10 @@ export function isGranularityGreaterOrEqual1h(granularity: string | undefined): 
   const value = parseInt(matches[1], 10);
   const unit = matches[2] as keyof typeof unitToSeconds;
 
-  // Convert granularity to seconds
+  // convert granularity to seconds
   const granularityInSeconds = value * unitToSeconds[unit];
 
-  // Check if granularity is greater than or equal to 1 hour (3600 seconds)
+  // check if granularity is greater than or equal to 1 hour (3600 seconds)
   return granularityInSeconds >= unitToSeconds['h'];
 }
 
@@ -67,7 +67,7 @@ export function splitRange(timeFrame: [start: number, end: number]): Range[] {
 
   let ranges = [];
 
-  // if period is bigger than 24
+  // check if period is bigger than 24
   if (difference > oneDay) {
     const end2Timestamp = endDate.getTime() - oneDay;
     const start2Timestamp = end2Timestamp;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { TimeRange } from '@grafana/data';
-import { Tuple } from './types';
+import {Range, Tuple} from './types';
 
 export function getRange(range: TimeRange): Tuple<number> {
   const timeFrom = range.from.valueOf();
@@ -26,4 +26,58 @@ export function stringifyDataError(error: any) {
     errorMessage = 'Unknown error';
   }
   return errorMessage;
+}
+
+export function isGranularityGreaterOrEqual1h(granularity: string | undefined): boolean {
+  if(!granularity) return false;
+  // Define the number of seconds for each unit
+  const unitToSeconds = {
+    s: 1,
+    m: 60,
+    h: 3600,
+    d: 86400,
+  };
+
+  // Extract the time value and the unit from the granularity string
+  const matches = granularity.match(/^(\d+)([smhd])$/);
+  if (!matches) {
+    throw new Error('Invalid granularity format');
+  }
+
+  const value = parseInt(matches[1], 10);
+  const unit = matches[2] as keyof typeof unitToSeconds;
+
+  // Convert granularity to seconds
+  const granularityInSeconds = value * unitToSeconds[unit];
+
+  // Check if granularity is greater than or equal to 1 hour (3600 seconds)
+  return granularityInSeconds >= unitToSeconds['h'];
+}
+
+export function splitRange(timeFrame: [start: number, end: number]): Range[] {
+  const start = timeFrame[0];
+  const end = timeFrame[1];
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+
+  const oneDay = 24 * 60 * 60 * 1000; // ms in one day
+  const difference = endDate.getTime() - startDate.getTime();
+
+  let ranges = [];
+
+  // if period is bigger than 24
+  if (difference > oneDay) {
+    const end2Timestamp = endDate.getTime() - oneDay;
+    const start2Timestamp = end2Timestamp;
+
+    ranges = [
+      {start, end: end2Timestamp, precomputed: true},
+      {start: start2Timestamp, end}
+    ]
+
+  } else {
+    ranges = [{start, end}];
+  }
+
+  return ranges;
 }


### PR DESCRIPTION
## Resolves #1 

## Describe your changes
Introduced logic for precomputed aggregates in addition to the existing default aggregates.

When rawDataEnabled is turned off, and the granularity exceeds 1h with a time range surpassing 24 hours, divide the single `/datapoints/aggregates` request into two: use `/datapoints/precomputed-aggregates` for data older than 24 hours and `/datapoints/aggregates` for the remaining data.

## How did you test it
`yarn run server:watch`
or
`yarn test`